### PR TITLE
feat(analytics): Add advanced dimension filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,26 @@ Get search performance data from Google Search Console with customizable paramet
 - `aggregationType`: Aggregation method (`auto`, `byNewsShowcasePanel`, `byProperty`, `byPage`)
 - `rowLimit`: Maximum rows to return (default: 1000)
 
-Example:
+**New Filter Parameters:**
+
+- `pageFilter`: Filter results by a specific page URL.
+- `queryFilter`: Filter results by a specific query string.
+- `countryFilter`: Filter by a country using ISO 3166-1 alpha-3 code (e.g., `USA`, `CHN`).
+- `deviceFilter`: Filter by device type (`DESKTOP`, `MOBILE`, `TABLET`).
+- `filterOperator`: The operator for `pageFilter` and `queryFilter`. Can be `equals`, `contains`, `notEquals`, or `notContains`. Defaults to `equals`.
+
+
+Example with Filters:
 
 ```json
 {
   "siteUrl": "https://example.com",
   "startDate": "2024-01-01",
   "endDate": "2024-01-31",
-  "dimensions": "query,country",
-  "type": "web",
-  "rowLimit": 500
+  "dimensions": "page,query",
+  "queryFilter": "ai assistant",
+  "filterOperator": "contains",
+  "deviceFilter": "MOBILE"
 }
 ```
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -30,6 +30,15 @@ export const SearchAnalyticsSchema = GSCBaseSchema.extend({
     .optional()
     .describe('Type of aggregation, such as auto, byNewsShowcasePanel, byProperty, byPage'),
   rowLimit: z.number().default(1000).describe('Maximum number of rows to return'),
+  pageFilter: z.string().optional().describe('Filter by a specific page URL. Use with filterOperator.'),
+  queryFilter: z.string().optional().describe('Filter by a specific query string. Use with filterOperator.'),
+  countryFilter: z.string().optional().describe('Filter by a country using ISO 3166-1 alpha-3 code (e.g., USA, CHN).'),
+  deviceFilter: z.enum(['DESKTOP', 'MOBILE', 'TABLET']).optional().describe('Filter by device type.'),
+  filterOperator: z
+    .enum(['equals', 'contains', 'notEquals', 'notContains'])
+    .default('equals')
+    .optional()
+    .describe('Operator for page and query filters. Defaults to "equals".'),
 });
 
 export const IndexInspectSchema = GSCBaseSchema.extend({


### PR DESCRIPTION
This commit enhances the 'search_analytics' tool by introducing comprehensive filtering capabilities, allowing for more granular and powerful data analysis.

Previously, the tool could only fetch broad performance data. With these changes, users can now drill down into specific segments.

Key changes include:
- Extended `SearchAnalyticsSchema` in `schemas.ts` to include optional filter parameters: `pageFilter`, `queryFilter`, `countryFilter`, and `deviceFilter`.
- Added a `filterOperator` parameter to allow choosing between 'equals' and 'contains' for more flexible filtering on pages and queries.
- Updated the handler in `index.ts` to dynamically construct the `dimensionFilterGroups` object based on the provided filter arguments.
- Updated `README.md` to document all new filter parameters and provided a new usage example.