### PR TITLE
fix: use undefined instead of false for sessionIdGenerator

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -33,7 +33,7 @@ app.all('/mcp', async (c) => {
   }
 
   const server = createServer(c.env.GOOGLE_CREDENTIALS);
-  const transport = new StreamableHTTPTransport({ sessionIdGenerator: false as any });
+  const transport = new StreamableHTTPTransport({ sessionIdGenerator: undefined });
 
   transport.onclose = () => {
     server.close().catch(() => {});


### PR DESCRIPTION
## Problem

`sessionIdGenerator: false as any` in `src/remote.ts` causes every POST to `/mcp` to fail with:

```
{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"TypeError: this[#sessionIdGenerator] is not a function"},"id":null}
```

## Root Cause

`@hono/mcp`'s `StreamableHTTPTransport` uses optional chaining to call the generator:

```ts
this.sessionId = this.#sessionIdGenerator?.();
```

Optional chaining (`?.`) only skips `undefined` and `null`, not `false`. So `false` is treated as a callable, resulting in `TypeError`.

## Fix

Pass `undefined` instead of `false as any` to correctly disable session ID generation.

## Testing

Tested locally with `wrangler dev` — all MCP operations (`initialize`, `tools/list`, `tools/call`) work correctly after the fix.